### PR TITLE
Fixed have_link Test

### DIFF
--- a/spec/sinatra_basic_forms_lab_spec.rb
+++ b/spec/sinatra_basic_forms_lab_spec.rb
@@ -10,12 +10,12 @@ describe App do
 
     it 'has a link with the text "List a Puppy"' do
       visit '/'
-      expect(page).to have_link("List a Puppy")
+      expect(page).to have_link('List a Puppy')
     end
 
     it 'has a link to list a puppy that links to /new' do
       visit '/'
-      expect(page).to have_link("List a Puppy", href: '/new')
+      expect(page).to have_link('List a Puppy', href: '/new')
     end
   end
 


### PR DESCRIPTION
Currently in Capybara, expect(page).to have_link("List a Puppy") checks for the literal value "List a Puppy" (including the quotes).

Capybara follows Ruby conventions, so updating the string to use single quotes, 'List a Puppy', now looks for the string without the quotes.